### PR TITLE
docs: add Docusaurus template documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,19 @@ Features are individually enabled in the solution file for code generation. Each
 becomes a separate workspace member crate. The `api`/`core` crates are self-contained — only
 the IPC and monitor features pull in transport dependencies.
 
+Full documentation is at **[apigear.io/template-rust](https://apigear.io/template-rust/docs/intro)**
+(start with the [feature overview](https://apigear.io/template-rust/docs/features/features)); each
+feature below links to its page.
+
 | Feature | Description | Dependencies |
 |---------|-------------|--------------|
-| **api** | Interface traits — awaitable `fn op() -> ApiFuture<…>` plus an ergonomic `async fn op_async()` companion; a `Publisher` (tokio `watch`/`broadcast`) for properties and signals; `ApiError`/`ApiFuture` | - |
-| **core** | Per-interface data structs and shared serde types | api |
-| **stubs** | Workspace, default trait implementations, examples, per-interface unit tests | api, core |
-| **monitor** | [`tracing`](https://docs.rs/tracing) decorator wrapping any implementation | api, core |
-| **olink** | [ObjectLink](https://objectlinkprotocol.net/) IPC adapters + in-process loopback tests | api, core |
-| **mqtt** | [MQTT](https://mqtt.org/) IPC adapters via [`rumqttc`](https://docs.rs/rumqttc) + broker integration tests | api, core |
-| **nats** | [NATS](https://nats.io/) IPC adapters via [`async-nats`](https://docs.rs/async-nats) + server integration tests | api, core |
+| **[api](https://apigear.io/template-rust/docs/features/api)** | Interface traits — awaitable `fn op() -> ApiFuture<…>` plus an ergonomic `async fn op_async()` companion; a `Publisher` (tokio `watch`/`broadcast`) for properties and signals; `ApiError`/`ApiFuture` | - |
+| **[core](https://apigear.io/template-rust/docs/features/api#data-types-core)** | Per-interface data structs and shared serde types | api |
+| **[stubs](https://apigear.io/template-rust/docs/features/stubs)** | Workspace, default trait implementations, examples, per-interface unit tests | api, core |
+| **[monitor](https://apigear.io/template-rust/docs/features/monitor)** | [`tracing`](https://docs.rs/tracing) decorator wrapping any implementation | api, core |
+| **[olink](https://apigear.io/template-rust/docs/features/olink)** | [ObjectLink](https://objectlinkprotocol.net/) IPC adapters + in-process loopback tests | api, core |
+| **[mqtt](https://apigear.io/template-rust/docs/features/mqtt)** | [MQTT](https://mqtt.org/) IPC adapters via [`rumqttc`](https://docs.rs/rumqttc) + broker integration tests | api, core |
+| **[nats](https://apigear.io/template-rust/docs/features/nats)** | [NATS](https://nats.io/) IPC adapters via [`async-nats`](https://docs.rs/async-nats) + server integration tests | api, core |
 
 ## Building
 

--- a/docs/docs/features/api.md
+++ b/docs/docs/features/api.md
@@ -1,0 +1,305 @@
+---
+sidebar_position: 1
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# API Feature
+
+The feature `api` is the bare minimum for code generation. It generates the trait-based API for your interfaces, the data types (structs and enums) defined in your module, a publisher for property changes and signals, and the shared error and future types. Together with the [core](#data-types-core) feature it produces a self-contained crate that compiles without any transport dependency.
+
+The `api` feature generates:
+
+- a trait for each defined _interface_, with awaitable operations and property accessors
+- an ergonomic `_async` companion for every operation
+- the `serde`-enabled [data structs and enums](#data-structs-and-enums) defined in your module
+- a [`Publisher`](#publisher) per interface, exposing property changes and signals over tokio channels
+- the shared [`ApiError` and `ApiFuture`](#apierror-and-apifuture) types
+
+:::note
+Check out the [stubs](stubs.md) feature, which provides a ready-to-use implementation of every trait generated here.
+:::
+
+### Files overview per module
+
+Using the example API definition
+
+<details>
+  <summary>Hello World API (click to expand)</summary>
+  <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+the following file structure is generated inside the module crate. The purpose and content of each file is explained below.
+
+```bash
+📂io_world
+ ┣ 📂src
+ ┃ ┣ 📂api
+ ┃ ┃ ┣ 📜mod.rs              # re-exports for the api module
+ ┃ ┃ ┣ 📜api_common.rs       # ApiError + ApiFuture
+ ┃ ┃ ┣ 📜data_structs.rs     # module-wide enums/structs (Message, WhenEnum)
+ ┃ ┃ ┗ 📜hello.rs            # HelloTrait, HelloTraitAsync, HelloPublisher
+ ┃ ┗ 📜lib.rs
+ ...
+```
+
+For each interface in the module a separate file is generated, like `📜hello.rs`. It contains the interface trait, its async companion trait, and the publisher.
+
+## Interface trait
+
+Every interface becomes a trait that is `Send + Sync`, so an implementation can be shared across threads and `await` points. For the `Hello` interface you get a `HelloTrait`:
+
+```rust
+use crate::api::data_structs::*;
+use crate::api::{ApiError, ApiFuture};
+
+pub trait HelloTrait: Send + Sync {
+    /// Operations return an awaitable, object-safe `ApiFuture`.
+    fn say(
+        &self,
+        msg: &Message,
+        when: WhenEnum,
+    ) -> ApiFuture<'_, Result<i32, ApiError>>;
+
+    /// Gets the value of the last property.
+    fn last(&self) -> Message;
+    /// Sets the value of the last property.
+    fn set_last(
+        &self,
+        last: &Message,
+    );
+
+    fn publisher(&self) -> &HelloPublisher;
+}
+```
+
+The trait has:
+
+- an **operation** for each method in the interface. Operations are object-safe and awaitable: they return an `ApiFuture` (see [below](#apierror-and-apifuture)). Returning a boxed future — instead of using `async fn` directly — keeps the trait object-safe, so it can be used behind `Arc<dyn HelloTrait>`.
+- a **getter and setter** for each property (here `last()` / `set_last()`).
+- an accessor for the [`Publisher`](#publisher).
+
+:::note
+The trait itself does not contain signals — signal emission and property-change notification are handled by the [`Publisher`](#publisher).
+:::
+
+### Async operations
+
+Calling an operation through the trait returns a future you `await`:
+
+```rust
+let result: Result<i32, ApiError> = object.say(&message, WhenEnum::Now).await;
+```
+
+For convenience, every interface also generates an **extension trait** `HelloTraitAsync` with an `_async` companion for each operation. It is provided through a blanket implementation for every implementor — including `dyn HelloTrait` — so it works on a trait object behind an `Arc` without any extra setup:
+
+```rust
+pub trait HelloTraitAsync: HelloTrait {
+    fn say_async(
+        &self,
+        msg: &Message,
+        when: WhenEnum,
+    ) -> impl std::future::Future<Output = Result<i32, ApiError>> + Send {
+        async move { self.say(msg, when).await }
+    }
+}
+
+impl<T: HelloTrait + ?Sized> HelloTraitAsync for T {}
+```
+
+Bring the `_async` trait into scope to call the ergonomic variant:
+
+```rust
+use io_world::api::hello::HelloTrait;
+use io_world::api::hello::HelloTraitAsync;
+
+let said = object.say_async(&message, WhenEnum::Now).await?;
+```
+
+Both forms do the same work; `say()` returns the boxed `ApiFuture` (useful in object-safe contexts), while `say_async()` reads more naturally at the call site.
+
+## Publisher
+
+The interface trait does not expose signals or change callbacks directly. Instead, each interface gets a `Publisher` struct that broadcasts property changes and signal emissions over [tokio](https://tokio.rs/) channels. Subscribers receive a channel receiver and react to changes asynchronously.
+
+```rust
+use tokio::sync::{watch, broadcast};
+
+pub struct HelloPublisher {
+    /// Property changes are delivered over a `watch` channel (latest value).
+    pub last_changed: watch::Sender<Message>,
+    /// Signals are delivered over a `broadcast` channel (every emission).
+    pub just_said: broadcast::Sender<(Message,)>,
+}
+```
+
+Each property gets a `watch::Sender` named `<property>_changed` (here `last_changed`), and each signal gets a `broadcast::Sender` named after the signal (here `just_said`).
+
+- **Property changes** use a tokio [`watch`](https://docs.rs/tokio/latest/tokio/sync/watch/) channel. A `watch` channel always holds the latest value, so a new subscriber immediately sees the current state. The implementation sends on the channel whenever the property changes.
+- **Signals** use a tokio [`broadcast`](https://docs.rs/tokio/latest/tokio/sync/broadcast/) channel, so every subscriber receives every emission. Signal payloads are delivered as a tuple of the signal parameters (here `(Message,)`).
+
+### Subscribe to changes and signals
+
+Subscribe by calling `subscribe()` on the relevant channel sender exposed by `publisher()`:
+
+```rust
+// React to property changes:
+let mut last_rx = object.publisher().last_changed.subscribe();
+tokio::spawn(async move {
+    while last_rx.changed().await.is_ok() {
+        let last = last_rx.borrow().clone();
+        println!("last property changed: {last:?}");
+    }
+});
+
+// React to a signal:
+let mut said_rx = object.publisher().just_said.subscribe();
+tokio::spawn(async move {
+    while let Ok((msg,)) = said_rx.recv().await {
+        println!("justSaid emitted: {msg:?}");
+    }
+});
+```
+
+:::note
+It is the implementation's responsibility to send on the publisher's channels when a property changes or a signal is emitted. The [stubs](stubs.md) feature already does this for you — see the generated default implementation.
+:::
+
+## ApiError and ApiFuture
+
+The shared `ApiError` and `ApiFuture` types are defined in `📜api_common.rs`, inside the `api` module. They have no transport or IPC dependency, so the `api` and `core` features stay self-contained.
+
+`ApiFuture` is a boxed, pinned, `Send` future — the return type of every trait operation:
+
+```rust
+use std::future::Future;
+use std::pin::Pin;
+
+/// A boxed, pinned future returned by async trait operations.
+/// Named `ApiFuture` (not `ApiResult`) because it wraps a `Future`, not a `Result`.
+pub type ApiFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+```
+
+`ApiError` is a [`thiserror`](https://docs.rs/thiserror)-derived enum covering the failure modes shared by local and IPC implementations:
+
+```rust
+#[derive(Debug, thiserror::Error)]
+pub enum ApiError {
+    #[error("operation failed: {0}")]
+    OperationFailed(String),
+    #[error("not connected")]
+    NotConnected,
+    #[error("serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("transport error: {0}")]
+    Transport(String),
+}
+```
+
+Local implementations typically return `Ok(...)`, while the IPC client adapters use `NotConnected` and `Transport` when the remote service is unavailable.
+
+## Data structs and enums
+
+The `api` feature also generates the data types defined in your module — the structs and enums referenced by your interfaces — into `📜src/api/data_structs.rs`. They carry `serde` derives so they can be serialized for the IPC transports. Bring them into scope with `use crate::api::data_structs::*;` (as the generated trait, implementation and adapter files do).
+
+### Structs
+
+Each struct in your API becomes a Rust struct with `serde` derives:
+
+```rust
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Message {
+    pub content: String,
+}
+```
+
+The derives give you, for free:
+
+- `Default` for zero-value construction
+- `Clone` and `PartialEq` for copying and comparison
+- `Serialize`/`Deserialize` for the IPC transports
+
+### Enums
+
+Each enum becomes a `#[repr(u8)]` Rust enum with `serde` derives and a `TryFrom<u8>` conversion for decoding wire values:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
+
+#[repr(u8)]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub enum WhenEnum {
+    #[default]
+    Now = 0,
+    Soon = 1,
+    Never = 2,
+}
+
+impl TryFrom<u8> for WhenEnum {
+    type Error = ();
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0 => Ok(WhenEnum::Now),
+            1 => Ok(WhenEnum::Soon),
+            2 => Ok(WhenEnum::Never),
+            _ => Err(()),
+        }
+    }
+}
+```
+
+The first member is marked `#[default]`, so `WhenEnum::default()` and `Default::default()` resolve to it.
+
+## Data types (core)
+
+The [`core`](features.md#core-features) feature generates the per-interface support types used for state synchronization and for passing implementations around, under `📂src/core_types/`. It does **not** generate your structs and enums — those come from the [`api`](#data-structs-and-enums) feature above. `core` is enabled automatically when you use [stubs](stubs.md) or any extended feature.
+
+For each interface it generates:
+
+- a **property bundle** struct that gathers all of the interface's properties for state sync
+- a **shared-reference** type alias and constructor for handing the implementation around as an `Arc`
+- a **test helper** that builds a populated instance of each data struct
+
+### Property bundle
+
+The property bundle (`📜src/core_types/hello_data.rs`) collects every property of the interface into one `serde`-enabled struct. The IPC adapters use it to send and receive the full initial state in a single message:
+
+```rust
+use crate::api::data_structs::*;
+use serde::{Deserialize, Serialize};
+
+/// Bundles all properties of Hello for state synchronization.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct HelloData {
+    pub last: Message,
+}
+```
+
+### Shared reference
+
+A type alias and constructor (`📜src/core_types/hello_shared.rs`) let you hand a trait object around as an `Arc`:
+
+```rust
+use std::sync::Arc;
+use crate::api::hello::HelloTrait;
+use crate::implementation::hello::Hello;
+
+/// Shared reference to a Hello implementation.
+pub type SharedHello = Arc<dyn HelloTrait>;
+
+/// Creates a new shared Hello with the default implementation.
+pub fn new_shared_hello() -> SharedHello {
+    Arc::new(Hello::default())
+}
+```
+
+This `Arc<dyn HelloTrait>` is exactly what the [monitor](monitor.md), [olink](olink.md), [mqtt](mqtt.md) and [nats](nats.md) features wrap, so the same implementation can be used locally and exposed over the network.
+
+:::note
+`new_shared_hello()` builds the default [stub](stubs.md) implementation, so the shared-reference helper is only generated when `stubs` is enabled. The `core` feature also generates a `📜test_helpers.rs` with a `fill_test_*` function per data struct, used by the generated tests.
+:::

--- a/docs/docs/features/data/helloworld.module.yaml
+++ b/docs/docs/features/data/helloworld.module.yaml
@@ -1,0 +1,29 @@
+schema: apigear.module/1.0
+name: io.world
+version: "1.0.0"
+
+interfaces:
+  - name: Hello
+    properties:
+      - { name: last, type: Message }
+    operations:
+      - name: say
+        params:
+          - { name: msg, type: Message }
+          - { name: when, type: When }
+        return:
+          type: int
+    signals:
+      - name: justSaid
+        params:
+          - { name: msg, type: Message }
+enums:
+  - name: When
+    members:
+      - { name: Now, value: 0 }
+      - { name: Soon, value: 1 }
+      - { name: Never, value: 2 }
+structs:
+  - name: Message
+    fields:
+      - { name: content, type: string }

--- a/docs/docs/features/features.md
+++ b/docs/docs/features/features.md
@@ -1,0 +1,98 @@
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# Features
+
+This guide explains how to use the generated code, what features are available, and their purpose.
+
+:::info
+A feature is a part of the template that generates a specific aspect of the code. For example, the `api` feature generates the interface traits and the publisher, while the `stubs` feature generates a default implementation you can build on.
+:::
+
+## Get started
+
+This template generates a [Cargo](https://doc.rust-lang.org/cargo/) workspace for pure _Rust_ projects. To successfully compile and use the code you need a working [Rust toolchain](https://www.rust-lang.org/tools/install) (`rustc` and `cargo`, 1.80 or newer). The generated code is asynchronous and built on [tokio](https://tokio.rs/).
+
+:::note
+Basic Rust knowledge is necessary.
+:::
+
+### Code generation
+
+Follow the documentation for [code generation](/docs/guide/quick-start) in general and the [CLI](/docs/cli/generate) or the [Studio](/docs/studio/intro) tools.
+Or try the [quick start guide](../quickstart/index.md) first, which shows how to prepare an API and generate code from it.
+
+:::tip
+For questions regarding the template please go to our [discussions page](https://github.com/orgs/apigear-io/discussions). For feature requests or bug reports please use our [issue tracker](https://github.com/apigear-io/template-rust/issues).
+:::
+
+### Example API
+
+The following code snippet contains the _API_ definition used throughout this guide to demonstrate the generated code and its usage.
+
+<details>
+    <summary>Hello World API (click to expand)</summary>
+    <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+## Features
+
+### Core Features
+
+The core features generate a working view of your _API_ definition. They are self-contained: the `api` and `core` features do **not** depend on any transport or IPC crate, so you can use the generated module crate in a pure in-process application.
+
+- [api](api.md) - generates the interface traits for your _API_, with awaitable operations and a `Publisher` (built on tokio channels) that exposes property changes and signals. Also generates the `serde`-enabled data structs and enums (`Serialize`/`Deserialize`, `TryFrom<u8>` for enums) defined in your module, and the shared `ApiError` and `ApiFuture` types.
+- [core](api.md#data-types-core) - generates per-interface support types under `core_types/`: a property-bundle struct for state synchronization, a shared-reference alias and constructor (`Arc<dyn Trait>`), and a test helper.
+- [stubs](stubs.md) - adds a ready-to-use default implementation of each interface trait, the workspace `Cargo.toml`, the `examples` crate, and per-interface unit tests. This is a good starting point for your own implementation.
+
+:::note
+The `stubs` feature requires `api` and `core`.
+:::
+
+### Extended Features
+
+The extended features build on top of `api` and `core` and add more functionality, like monitoring or sharing your data over the network (see [olink](olink.md), [mqtt](mqtt.md), [nats](nats.md)).
+
+- [monitor](monitor.md) - generates a [`tracing`](https://docs.rs/tracing) decorator that wraps any implementation and logs all operations and state changes to the [CLI](/docs/cli/intro) or the [Studio](/docs/studio/intro).
+- [olink](olink.md) - provides a client and a service adapter for each interface that can be connected to any of the other technology templates with support for [ObjectLink](/docs/protocols/objectlink/intro). Use this feature to connect with the ApiGear simulation tools. Includes in-process loopback round-trip tests.
+- [mqtt](mqtt.md) - provides client and service adapters for each interface over the [MQTT](https://mqtt.org/) protocol (via the [`rumqttc`](https://docs.rs/rumqttc) crate). Check also MQTT in other technology templates that support it. Includes broker-backed integration tests.
+- [nats](nats.md) - provides client and service adapters for each interface over the [NATS](https://nats.io/) protocol (via the [`async-nats`](https://docs.rs/async-nats) crate). Check also NATS in other technology templates that support it. Includes server-backed integration tests.
+- examples - a shared `examples` crate with runnable programs: a local example exercising every interface in-process, plus `*_server` and `*_client` binaries for each IPC transport (OLink over TCP, MQTT and NATS over a broker/server). Run them with `cargo run`.
+
+Each feature can be selected using the solution file or via the command line tool.
+
+:::note
+_Features are case sensitive, make sure to always **use lower-case.**_
+:::
+
+:::tip
+The _meta_ feature `all` enables all specified features of the template. If you want to see the full extent of the generated code, `all` is the easiest solution.
+Please note, `all` is part of the code generator and not explicitly defined within templates.
+:::
+
+## Folder structure
+
+This graph shows the folder structure generated with `all` features enabled. Each module becomes its own workspace member crate (here `io_world`), and the shared `examples` crate sits next to it at the workspace root (here `rust_hello_world`). For more details visit the documentation for each feature.
+
+```bash
+📂hello-world
+ ┣ 📂apigear
+ ┃ ┣ 📜helloworld.solution.yaml
+ ┃ ┗ 📜helloworld.module.yaml
+ ┣ 📂rust_hello_world
+ ┃ ┣ 📜Cargo.toml          # workspace manifest
+ ┃ ┣ 📜rustfmt.toml
+ ┃ ┣ 📂examples            # runnable example programs (local + IPC client/server)
+ ┃ ┗ 📂io_world            # one crate per module
+ ┃ ┃ ┣ 📜Cargo.toml
+ ┃ ┃ ┣ 📂src
+ ┃ ┃ ┃ ┣ 📜lib.rs
+ ┃ ┃ ┃ ┣ 📂api             # api feature: traits + Publisher + data structs/enums + ApiError/ApiFuture
+ ┃ ┃ ┃ ┣ 📂core_types      # core feature: property bundle + shared reference + test helpers
+ ┃ ┃ ┃ ┣ 📂implementation  # stubs feature: default implementation
+ ┃ ┃ ┃ ┣ 📂monitor         # monitor feature: tracing decorator
+ ┃ ┃ ┃ ┣ 📂olink           # olink feature: client + service adapters
+ ┃ ┃ ┃ ┣ 📂mqtt            # mqtt feature: client + service adapters
+ ┃ ┃ ┃ ┗ 📂nats            # nats feature: client + service adapters
+ ┃ ┃ ┗ 📂tests             # unit tests + IPC round-trip tests
+```

--- a/docs/docs/features/monitor.md
+++ b/docs/docs/features/monitor.md
@@ -1,0 +1,121 @@
+---
+sidebar_position: 4
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# Monitor
+
+Use the monitor feature to observe interface calls and state changes at runtime. It generates a [`tracing`](https://docs.rs/tracing) decorator that wraps any implementation of your interface and emits a tracing event for every operation and property change. Because the decorator implements the same interface trait, you can drop it in wherever your implementation is used.
+
+The monitoring server is embedded into [ApiGear Studio](/docs/studio/intro) and the [CLI](/docs/cli/intro). For more details see the [monitoring documentation](/docs/monitor/intro).
+
+:::note
+This feature requires `api` and `core`.
+:::
+
+## File overview for module
+
+With our example API definition
+
+<details>
+    <summary>Hello World API (click to expand)</summary>
+    <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+the following files are generated. The purpose and content of each file is explained below.
+
+```bash {7}
+📂io_world
+ ┣ 📂src
+ ┃ ┣ 📂monitor
+ ┃ ┃ ┣ 📜mod.rs
+ ┃ ┃ ┗ 📜hello_traced.rs   # tracing decorator for Hello
+ ┃ ┗ 📜lib.rs
+ ...
+```
+
+## The tracing decorator
+
+The file `📜hello_traced.rs` contains a `HelloTraced<T>` decorator. It is generic over any `T: HelloTrait`, wraps an inner implementation, and implements `HelloTrait` itself by logging a [`tracing`](https://docs.rs/tracing) event and then forwarding the call to the inner object.
+
+```rust
+use crate::api::data_structs::*;
+use crate::api::{ApiError, ApiFuture};
+use crate::api::hello::HelloPublisher;
+use crate::api::hello::HelloTrait;
+use tracing;
+
+/// Trace decorator for Hello.
+/// Wraps any implementation and instruments all operations with tracing spans.
+pub struct HelloTraced<T: HelloTrait> {
+    inner: T,
+}
+
+impl<T: HelloTrait> HelloTraced<T> {
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+impl<T: HelloTrait> HelloTrait for HelloTraced<T> {
+    fn say(
+        &self,
+        msg: &Message,
+        when: WhenEnum,
+    ) -> ApiFuture<'_, Result<i32, ApiError>> {
+        tracing::info!("Hello::say called");
+        self.inner.say(msg, when)
+    }
+
+    fn last(&self) -> Message {
+        self.inner.last() // getters are forwarded without tracing
+    }
+    fn set_last(
+        &self,
+        last: &Message,
+    ) {
+        tracing::info!("Hello::set_last called");
+        self.inner.set_last(last);
+    }
+
+    fn publisher(&self) -> &HelloPublisher {
+        self.inner.publisher()
+    }
+}
+```
+
+Operations and property setters are logged; getters and the `publisher()` accessor are forwarded unchanged. Since `HelloTraced<T>` is itself a `HelloTrait`, you can use it anywhere the plain implementation fits — including in front of an IPC client adapter.
+
+:::note
+The wrapped `inner` value just has to satisfy the `HelloTrait` bound, so it can be the default [stub](stubs.md) implementation, an [OLink client](olink.md), or any other implementation.
+:::
+
+## Use the decorator
+
+Wrap your implementation with `HelloTraced::new(...)` and use the result as a `Hello` object. Every traced call produces a `tracing` event that a configured subscriber can forward to the ApiGear monitoring server.
+
+```rust
+use io_world::api::hello::HelloTrait;
+use io_world::api::hello::HelloTraitAsync;
+use io_world::implementation::hello::Hello;
+use io_world::monitor::hello_traced::HelloTraced;
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    // Set up a tracing subscriber (here: log to stdout).
+    tracing_subscriber::fmt::init();
+
+    // Wrap the default implementation with the tracing decorator.
+    let hello = HelloTraced::new(Hello::default());
+
+    // Use it exactly like a Hello implementation — every call is traced.
+    let _ = hello.say_async(&Default::default(), Default::default()).await;
+    hello.set_last(&Default::default());
+}
+```
+
+:::tip
+The `tracing` crate decouples *emitting* events from *collecting* them. Install any [`tracing-subscriber`](https://docs.rs/tracing-subscriber) layer to control where the events go — the console for local development, or an exporter that forwards them to the [ApiGear Studio](/docs/studio/intro) or [CLI](/docs/cli/intro) monitor.
+:::

--- a/docs/docs/features/mqtt.md
+++ b/docs/docs/features/mqtt.md
@@ -1,0 +1,132 @@
+---
+sidebar_position: 5
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# MQTT
+
+This feature provides a _client_ and a _service_ adapter for your interfaces over the [MQTT](https://mqtt.org/) protocol, built on the [`rumqttc`](https://docs.rs/rumqttc) crate. It lets you connect applications built with the same or different technologies — check all of our [templates](/docs/sdk/intro) and the MQTT feature in other templates that support it.
+
+- Use an _MQTT client_ in place of your local implementation to receive data from a remote service.
+- Use an _MQTT service adapter_ to expose your implementation as a remote service.
+
+:::note
+This feature requires `api` and `core`.
+:::
+
+:::tip
+The MQTT broker is not part of the template. To run a client and a service you need a broker (for example [Mosquitto](https://mosquitto.org/)) reachable by both.
+:::
+
+## File overview for module
+
+With our example API definition
+
+<details>
+  <summary>Hello World API (click to expand)</summary>
+  <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+the following files are generated. The purpose and content of each file is explained below.
+
+```bash {7,8,13}
+📂io_world
+ ┣ 📂src
+ ┃ ┣ 📂mqtt
+ ┃ ┃ ┣ 📜mod.rs
+ ┃ ┃ ┣ 📜hello_client.rs    # MQTT client adapter for Hello
+ ┃ ┃ ┗ 📜hello_service.rs   # MQTT service adapter for Hello
+ ┃ ┗ 📜lib.rs
+ ┣ 📂tests
+ ┃ ┣ 📜mqtt_common.rs       # broker test helper
+ ┃ ┗ 📜mqtt_hello_test.rs   # round-trip tests for Hello
+ ...
+```
+
+The adapters map your interface onto MQTT topics: operations are published as request messages, while properties, signals and the service's state use dedicated topics. The service publishes property and state messages as retained, so a client that connects later still receives the current state.
+
+## MQTT client adapter
+
+The file `📜hello_client.rs` contains `HelloMqttClient`, the MQTT client version of the `Hello` interface. It implements `HelloTrait`, so you use it like a local implementation. It takes a shared [`rumqttc`](https://docs.rs/rumqttc) `AsyncClient`, subscribes to the interface's topics, and decodes incoming messages.
+
+```rust
+let client = Arc::new(HelloMqttClient::new(Arc::new(mqtt_async_client)));
+client.subscribe_topics().await.expect("subscribe to topics");
+```
+
+#### Properties
+
+A getter (here `last()`) returns the locally cached value last received from the service. A setter (here `set_last()`) publishes a change request; the local value updates when the service confirms the change. Subscribe to changes through the [`Publisher`](api.md#publisher) returned by `publisher()`.
+
+:::note
+Property and state messages are retained on the broker, so a client connecting after the service started still receives the current property values.
+:::
+
+#### Operations
+
+Operations are published as request messages and awaited:
+
+```rust
+let result = client.say(&message, WhenEnum::Now).await;
+```
+
+#### Signals
+
+Do not emit signals from a client. Subscribe to signals through the [`Publisher`](api.md#publisher); incoming signal messages are delivered on the matching `broadcast` channel.
+
+## MQTT service adapter
+
+The file `📜hello_service.rs` contains `HelloMqttService`, which wraps a local `Hello` implementation and exposes it over MQTT. It applies incoming operation and property-change requests to your local object and publishes property changes and signals back to clients.
+
+- **Properties** — a change on your local object (or a client request) is published to all clients.
+- **Operations** — a request is run on your local object; the result is returned only to the requesting client.
+- **Signals** — a signal emitted by your local object is forwarded to all clients.
+
+## Use the adapters
+
+The generated `examples` crate ships ready-to-run `mqtt_server` and `mqtt_client` binaries. The client creates a `rumqttc` `AsyncClient`, hands it to the adapter, and pumps the MQTT event loop so the adapter receives state, property changes and signals:
+
+```rust
+use rumqttc::{AsyncClient, Event, MqttOptions, Packet};
+use std::sync::Arc;
+use std::time::Duration;
+
+let mut opts = MqttOptions::new("hello-client", "127.0.0.1", 1883);
+opts.set_keep_alive(Duration::from_secs(5));
+let (mqtt, mut eventloop) = AsyncClient::new(opts, 64);
+
+let client = Arc::new(HelloMqttClient::new(Arc::new(mqtt)));
+client.subscribe_topics().await.expect("subscribe to topics");
+
+// Drive the event loop so incoming messages reach the adapter.
+let pump = client.clone();
+tokio::spawn(async move {
+    loop {
+        if let Ok(Event::Incoming(Packet::Publish(p))) = eventloop.poll().await {
+            pump.handle_message(&p.topic, &p.payload);
+        }
+    }
+});
+
+// Use the client like a local Hello implementation:
+let _ = client.say(&Default::default(), WhenEnum::Now).await;
+```
+
+Start a broker, then run the two binaries in separate terminals (override the broker port with the `MQTT_PORT` environment variable, default `1883`):
+
+```bash
+mosquitto -p 1883 &
+cargo run -p rust_hello_world_examples --bin mqtt_server
+cargo run -p rust_hello_world_examples --bin mqtt_client
+```
+
+## Tests
+
+The MQTT feature generates round-trip tests in `📜tests/mqtt_hello_test.rs`, backed by the helper in `📜mqtt_common.rs`. They exercise a real client ↔ service round-trip over a live broker, so they are marked `#[ignore]` and skipped by default. Run them against a broker the way CI does:
+
+```bash
+mosquitto -p 1883 &
+cargo test --manifest-path goldenmaster/Cargo.toml -- --ignored
+```

--- a/docs/docs/features/nats.md
+++ b/docs/docs/features/nats.md
@@ -1,0 +1,124 @@
+---
+sidebar_position: 6
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# NATS
+
+This feature provides a _client_ and a _service_ adapter for your interfaces over the [NATS](https://nats.io/) protocol, built on the [`async-nats`](https://docs.rs/async-nats) crate. It lets you connect applications built with the same or different technologies — check all of our [templates](/docs/sdk/intro) and the NATS feature in other templates that support it.
+
+- Use a _NATS client_ in place of your local implementation to receive data from a remote service.
+- Use a _NATS service adapter_ to expose your implementation as a remote service.
+
+:::note
+This feature requires `api` and `core`.
+:::
+
+:::tip
+The NATS server is not part of the template. To run a client and a service (both connect as NATS clients) you need a [nats-server](https://nats.io/download/) reachable by both.
+:::
+
+## File overview for module
+
+With our example API definition
+
+<details>
+  <summary>Hello World API (click to expand)</summary>
+  <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+the following files are generated. The purpose and content of each file is explained below.
+
+```bash {7,8,13}
+📂io_world
+ ┣ 📂src
+ ┃ ┣ 📂nats
+ ┃ ┃ ┣ 📜mod.rs
+ ┃ ┃ ┣ 📜hello_client.rs    # NATS client adapter for Hello
+ ┃ ┃ ┗ 📜hello_service.rs   # NATS service adapter for Hello
+ ┃ ┗ 📜lib.rs
+ ┣ 📂tests
+ ┃ ┣ 📜nats_common.rs       # server test helper
+ ┃ ┗ 📜nats_hello_test.rs   # round-trip tests for Hello
+ ...
+```
+
+The adapters use NATS request/reply for operations and dedicated subjects for properties, signals and the service's state.
+
+## NATS client adapter
+
+The file `📜hello_client.rs` contains `HelloNatsClient`, the NATS client version of the `Hello` interface. It implements `HelloTrait`, so you use it like a local implementation. It takes a connected [`async-nats`](https://docs.rs/async-nats) client and subscribes to the interface's subjects.
+
+```rust
+let nats = async_nats::connect("127.0.0.1:4222").await?;
+let client = Arc::new(HelloNatsClient::new(nats));
+let _subscription = client.subscribe();
+```
+
+#### Properties
+
+A getter (here `last()`) returns the locally cached value last received from the service. A setter (here `set_last()`) sends a change request; the local value updates when the service confirms the change. Subscribe to changes through the [`Publisher`](api.md#publisher) returned by `publisher()`.
+
+#### Operations
+
+Operations use NATS request/reply — the call sends a request and awaits the reply:
+
+```rust
+let result = client.say(&message, WhenEnum::Now).await;
+```
+
+#### Signals
+
+Do not emit signals from a client. Subscribe to signals through the [`Publisher`](api.md#publisher); incoming signal messages are delivered on the matching `broadcast` channel.
+
+#### Connectivity
+
+The client's `subscribe()` spawns a background task that subscribes to the property (`apigear.io.world.Hello.prop.*`), signal (`apigear.io.world.Hello.sig.*`) and state (`apigear.io.world.Hello.state`) subjects, and keeps the cache in sync as messages arrive. The service publishes its full state on the `.state` subject via `publish_state()`. Because NATS does not retain messages, a client that connects after the service published only sees the state if the service publishes it again — the generated `nats_server` example re-publishes the state periodically so late-joining clients still receive it.
+
+## NATS service adapter
+
+The file `📜hello_service.rs` contains `HelloNatsService`, which wraps a local `Hello` implementation and exposes it over NATS. It applies incoming operation and property-change requests to your local object and publishes property changes and signals back to clients.
+
+- **Properties** — a change on your local object (or a client request) is published to all clients.
+- **Operations** — a request is run on your local object; the result is returned only to the requesting client.
+- **Signals** — a signal emitted by your local object is forwarded to all clients.
+
+## Use the adapters
+
+The generated `examples` crate ships ready-to-run `nats_server` and `nats_client` binaries. The client connects to the server, hands the connection to the adapter, and subscribes:
+
+```rust
+use std::sync::Arc;
+use std::time::Duration;
+
+let nats = async_nats::connect("127.0.0.1:4222").await.expect("connect to nats-server");
+
+let client = Arc::new(HelloNatsClient::new(nats));
+let _subscription = client.subscribe();
+
+// Give the subscriptions and state exchange a moment.
+tokio::time::sleep(Duration::from_millis(500)).await;
+
+// Use the client like a local Hello implementation:
+let result = client.say(&Default::default(), WhenEnum::Now).await;
+println!("say() -> {result:?}");
+```
+
+Start a server, then run the two binaries in separate terminals (override the server URL with the `NATS_URL` environment variable, default `127.0.0.1:4222`):
+
+```bash
+nats-server -p 4222 &
+cargo run -p rust_hello_world_examples --bin nats_server
+cargo run -p rust_hello_world_examples --bin nats_client
+```
+
+## Tests
+
+The NATS feature generates round-trip tests in `📜tests/nats_hello_test.rs`, backed by the helper in `📜nats_common.rs`. They exercise a real client ↔ service round-trip over a live server, so they are marked `#[ignore]` and skipped by default. Run them against a server the way CI does:
+
+```bash
+nats-server -p 4222 &
+cargo test --manifest-path goldenmaster/Cargo.toml -- --ignored
+```

--- a/docs/docs/features/olink.md
+++ b/docs/docs/features/olink.md
@@ -1,0 +1,161 @@
+---
+sidebar_position: 3
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# Olink
+
+This feature provides a _client_ and a _service_ adapter for your interfaces over the [ObjectLink](/docs/protocols/objectlink/intro) protocol. It lets you connect applications built with the same or different technologies — check all of our [templates](/docs/sdk/intro).
+
+Use an _OLink client_ in place of your local implementation to talk to a remote service or to the [ApiGear simulation](#simulation). Use an _OLink service adapter_ to expose your implementation as a remote service.
+
+:::note
+This feature requires `api` and `core`.
+:::
+
+### ApiGear ObjectLink protocol
+
+The [ObjectLink](/docs/protocols/objectlink/intro) protocol is a lightweight message protocol for objects described by an interface. It connects a client object with a server object and supports remote operations: requesting a property change (client) or notifying a property change (server), emitting a signal (server), and invoking a remote method with a response delivered to the caller (server).
+
+The OLink adapters build on the [objectlink-core-rs](https://github.com/apigear-io/objectlink-core-rs) library (the `objectlink-core` crate), which is shared across Rust-based ObjectLink code. It provides the protocol abstraction — encoding and decoding messages and routing them to the right object through a registry — independent of the network stack. Messages are exchanged as newline-delimited JSON, so any byte stream (a TCP socket, an in-process loopback) can carry them.
+
+## File overview for module
+
+With our example API
+
+<details>
+  <summary>Hello World API (click to expand)</summary>
+  <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+the following files are generated. The purpose and content of each file is explained below.
+
+```bash {7,8,13}
+📂io_world
+ ┣ 📂src
+ ┃ ┣ 📂olink
+ ┃ ┃ ┣ 📜mod.rs
+ ┃ ┃ ┣ 📜hello_client.rs    # OLink client adapter for Hello
+ ┃ ┃ ┗ 📜hello_service.rs   # OLink service adapter for Hello
+ ┃ ┗ 📜lib.rs
+ ┣ 📂tests
+ ┃ ┣ 📜olink_common.rs      # in-process loopback helper
+ ┃ ┗ 📜olink_hello_test.rs  # round-trip tests for Hello
+ ...
+```
+
+## OLink client adapter
+
+The file `📜hello_client.rs` contains `HelloOlinkClient`, the OLink client version of the `Hello` interface. It implements two traits: `HelloTrait` (so you can use it exactly like a local implementation) and `ObjectSink` (so the OLink core can deliver incoming messages to it). It caches property values locally and forwards operations and property writes to the remote service.
+
+```rust
+pub struct HelloOlinkClient {
+    data: RwLock<HelloData>,                  // locally cached property values
+    node: RwLock<Option<Arc<dyn IClientNode>>>,
+    publisher: HelloPublisher,
+}
+```
+
+#### Properties
+
+A property getter (here `last()`) returns the locally cached value last received from the service. A property setter (here `set_last()`) sends a change request to the service; the local value is **not** changed immediately — it updates when the service confirms the change. Subscribe to changes through the [`Publisher`](api.md#publisher) returned by `publisher()`. When the client receives a property-change message, it updates its cache and sends on the matching `watch` channel.
+
+:::note
+On a successful link, the client receives the service's current state, so its cached properties start in sync with the service.
+:::
+
+#### Operations
+
+Operations are forwarded as remote invocations. Calling an operation sends an invoke request to the service and awaits the reply:
+
+```rust
+let result = client.say(&message, WhenEnum::Now).await;
+```
+
+If no client node has been set or the link is down, the operation resolves to `Err(ApiError::NotConnected)`.
+
+#### Signals
+
+Do not emit signals from a client. Subscribe to any signal through the [`Publisher`](api.md#publisher); when the client receives a signal message it sends on the matching `broadcast` channel.
+
+## OLink service adapter
+
+The file `📜hello_service.rs` contains `HelloOlinkService`, which wraps a local `Hello` implementation and exposes it to remote clients by implementing the `ObjectSource` trait from [objectlink-core-rs](https://github.com/apigear-io/objectlink-core-rs). It receives remote invocations and property-change requests, applies them to your local object, and pushes property changes and signals back to connected clients. Construct it with the shared implementation you want to expose:
+
+```rust
+let object: Arc<dyn HelloTrait> = Arc::new(Hello::default());
+let service = HelloOlinkService::new(object.clone());
+```
+
+- **Properties** — a property change on your local object (or a change requested by a client) is published to all connected clients.
+- **Operations** — a remote invocation is run on your local object; the result is returned only to the calling client.
+- **Signals** — a signal emitted by your local object is forwarded to all connected clients.
+
+## Use the adapters
+
+The adapters need a transport to carry the ObjectLink messages. The generated `examples` crate ships ready-to-run `olink_server` and `olink_client` binaries that wire the adapters to a TCP socket. The service side registers the adapter and pumps socket lines through a `RemoteNode`:
+
+```rust
+use objectlink_core::remote_node::RemoteNode;
+use objectlink_core::remote_registry::RemoteRegistry;
+use objectlink_core::traits::ObjectSource;
+use std::sync::Arc;
+
+let object = Arc::new(Hello::default());
+let service: Arc<dyn ObjectSource> =
+    Arc::new(HelloOlinkService::new(object.clone() as Arc<dyn HelloTrait>));
+
+let registry = Arc::new(RemoteRegistry::new());
+registry.add_source(Arc::downgrade(&service));
+// Accept TCP connections and feed each incoming line to `node.handle_message(&line)`.
+```
+
+The client side connects a `HelloOlinkClient` through a `ClientNode` and links it to the remote object:
+
+```rust
+use objectlink_core::client_node::ClientNode;
+use objectlink_core::client_registry::ClientRegistry;
+use objectlink_core::traits::ObjectSink;
+use std::sync::Arc;
+
+let registry = Arc::new(ClientRegistry::new());
+let node = Arc::new(ClientNode::new(registry));
+
+let client = Arc::new(HelloOlinkClient::default());
+client.set_node(node.clone());
+let sink: Arc<dyn ObjectSink> = client.clone();
+node.link_remote(&sink);
+
+// Once linked, use the client like a local Hello implementation:
+let _ = client.say(&Default::default(), WhenEnum::Now).await;
+println!("last = {:?}", client.last());
+```
+
+Run the two binaries in separate terminals (override the address with the `OLINK_ADDR` environment variable, default `127.0.0.1:8182`):
+
+```bash
+cargo run -p rust_hello_world_examples --bin olink_server
+cargo run -p rust_hello_world_examples --bin olink_client
+```
+
+## Tests
+
+The OLink feature generates round-trip tests in `📜tests/olink_hello_test.rs`, backed by an in-process loopback helper in `📜olink_common.rs`. The loopback wires a service adapter and a client adapter together without a socket, so the tests verify the full client ↔ service round-trip — operations, property writes, remote property notifications, and signals — entirely in-memory. They run as part of `cargo test` and require no broker:
+
+```bash
+cargo test --manifest-path goldenmaster/Cargo.toml
+```
+
+## Simulation
+
+The simulation lets you test, demonstrate or develop applications without the real service. The simulation server is integrated into [ApiGear Studio](/docs/studio/intro) and the [CLI](/docs/cli/simulate). Because the simulation speaks ObjectLink, point your `HelloOlinkClient` at the simulation server's address instead of a real service and it behaves like a remote implementation.
+
+You drive the simulation with [simulation scenarios](/docs/scripting/backends/scenario) — YAML files that define sequences of actions that change property values or emit signals. See more on [simulation](/docs/scripting/backends/intro).
+
+Run a scenario from the CLI and connect your client to the same port:
+
+```bash
+apigear simulate run path/to/helloworldtest.scenario.yaml --addr :8182
+```

--- a/docs/docs/features/stubs.md
+++ b/docs/docs/features/stubs.md
@@ -1,0 +1,177 @@
+---
+sidebar_position: 2
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import helloWorldModuleComponent from '!!raw-loader!./data/helloworld.module.yaml';
+
+# Stubs
+
+The feature `stubs` turns the bare [api](api.md) traits into a runnable workspace. It adds:
+
+- a ready-to-use default implementation of every interface trait — a good starting point for your own logic
+- the workspace `Cargo.toml` and `rustfmt.toml`
+- the `examples` crate with runnable programs
+- per-interface unit tests
+
+:::note
+The `stubs` feature requires `api` and `core`. Enabling it pulls them in automatically.
+:::
+
+### File overview
+
+With our example API definition
+
+<details>
+  <summary>Hello World API (click to expand)</summary>
+  <CodeBlock language="yaml" showLineNumbers>{helloWorldModuleComponent}</CodeBlock>
+</details>
+
+the following files are generated. The purpose and content of each file is explained below.
+
+```bash {3,5,11,14}
+📂rust_hello_world
+ ┣ 📜Cargo.toml                          # workspace manifest (system scope)
+ ┣ 📜rustfmt.toml
+ ┣ 📂examples                            # runnable example programs (system scope)
+ ┃ ┣ 📜Cargo.toml
+ ┃ ┗ 📂src
+ ┃ ┃ ┣ 📜main.rs                         # local in-process example
+ ┃ ┃ ┗ 📂bin                             # IPC client/server binaries
+ ┃ ┗ ...
+ ┗ 📂io_world
+ ┃ ┣ 📜Cargo.toml                        # module crate manifest
+ ┃ ┣ 📂src
+ ┃ ┃ ┣ 📜lib.rs
+ ┃ ┃ ┗ 📂implementation
+ ┃ ┃ ┃ ┣ 📜mod.rs
+ ┃ ┃ ┃ ┗ 📜hello.rs                      # default Hello implementation
+ ┃ ┗ 📂tests
+ ┃ ┃ ┗ 📜implementation_hello_test.rs    # unit tests for Hello
+```
+
+## Implementation
+
+The file `📜implementation/hello.rs` contains the default implementation of `HelloTrait`. It is a regular struct that:
+
+- stores each property behind a [`parking_lot::RwLock`](https://docs.rs/parking_lot) for interior mutability, so the methods take `&self` (matching the object-safe trait) yet can still mutate state
+- owns a [`HelloPublisher`](api.md#publisher) and returns it through `publisher()`
+- implements the property getters and setters, sending on the publisher's channel on every actual change
+- provides a default body for each operation for you to fill with your business logic
+
+```rust
+use crate::api::hello::HelloTrait;
+use crate::api::data_structs::*;
+use crate::api::{ApiError, ApiFuture};
+use crate::api::hello::HelloPublisher;
+use parking_lot::RwLock;
+
+pub struct Hello {
+    last: RwLock<Message>,
+    publisher: HelloPublisher,
+}
+
+impl Default for Hello {
+    fn default() -> Self {
+        Self { last: RwLock::new(Default::default()), publisher: Default::default() }
+    }
+}
+
+impl HelloTrait for Hello {
+    fn say(
+        &self,
+        _msg: &Message,
+        _when: WhenEnum,
+    ) -> ApiFuture<'_, Result<i32, ApiError>> {
+        // Fill in your business logic here.
+        Box::pin(async move { Ok(Default::default()) })
+    }
+
+    fn last(&self) -> Message {
+        self.last.read().clone()
+    }
+    fn set_last(
+        &self,
+        last: &Message,
+    ) {
+        let new_val = last.clone();
+        let mut value = self.last.write();
+        if *value == new_val {
+            return; // skip notification if the value did not change
+        }
+        *value = new_val.clone();
+        // Notify subscribers of the change.
+        let _ = self.publisher.last_changed.send(new_val);
+    }
+
+    fn publisher(&self) -> &HelloPublisher {
+        &self.publisher
+    }
+}
+```
+
+:::tip
+When adding your own logic, remember to send on the publisher's channels each time you want a property change to be shared or a signal to be emitted — just like the generated setters do.
+:::
+
+:::note
+The setter skips the notification when the new value equals the current one, so subscribers are only woken on a real change.
+:::
+
+### Shared constructor
+
+Alongside each implementation, the [core](api.md#data-types-core) feature generates a shared type alias and constructor in `📜src/core_types/hello_shared.rs`, so you can hand a trait object around as an `Arc`:
+
+```rust
+use std::sync::Arc;
+use crate::api::hello::HelloTrait;
+use crate::implementation::hello::Hello;
+
+/// Shared reference to a Hello implementation.
+pub type SharedHello = Arc<dyn HelloTrait>;
+
+/// Creates a new shared Hello with the default implementation.
+pub fn new_shared_hello() -> SharedHello {
+    Arc::new(Hello::default())
+}
+```
+
+This `Arc<dyn HelloTrait>` is exactly what the [monitor](monitor.md), [olink](olink.md), [mqtt](mqtt.md) and [nats](nats.md) features wrap, so the same implementation can be used locally and exposed over the network.
+
+## The examples crate
+
+The `📂examples` crate is generated once per workspace (system scope). Its `src/main.rs` instantiates every interface's default implementation in-process and exercises it — calling the first operation through the `_async` companion, setting each property, and reporting how many signals are available through the publisher. Run it with:
+
+```bash
+cargo run -p rust_hello_world_examples
+```
+
+The `examples/src/bin/` folder additionally contains `*_server` and `*_client` binaries for each IPC transport. They are documented with the [olink](olink.md), [mqtt](mqtt.md) and [nats](nats.md) features.
+
+## Build on the stub
+
+The default implementation is the recommended starting point. A typical workflow:
+
+1. Generate with the `stubs` feature (and any IPC features you need).
+2. Fill in the operation bodies in `📂implementation/*.rs` with your logic.
+3. Send on the publisher's signal channels wherever your logic emits a signal.
+4. Use your implementation locally, or wrap it with a [monitor](monitor.md) decorator or an IPC service adapter to share it over the network.
+
+:::note
+Set `force: false` in your solution file for the `stubs` target if you don't want your filled-in implementations overwritten on regeneration. The [api](api.md) and [core](api.md#data-types-core) files are always regenerated.
+:::
+
+## Tests
+
+For each interface a unit test file is generated, like `📜tests/implementation_hello_test.rs`. It instantiates the default implementation and exercises each operation through both the `ApiFuture` form and the `_async` companion. These tests run as part of `cargo test` (no broker required) and are a starting point for your own tests:
+
+```rust
+#[tokio::test]
+async fn test_say() {
+    let test_object = Hello::default();
+    let result = test_object.say(&Default::default(), Default::default()).await;
+    assert!(result.is_ok());
+    let result_async = test_object.say_async(&Default::default(), Default::default()).await;
+    assert!(result_async.is_ok());
+}
+```

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -1,0 +1,12 @@
+---
+sidebar_position: 1
+---
+
+# Template Rust
+
+This is the documentation for the _rust_ template for the [ApiGear](/docs/guide/quick-start) code generator.
+
+It is split in several parts:
+
+- [Quick-Start](quickstart/index.md?current-template=template-rust) is the easiest way to get started
+- [Features](features/features.md) explains the available code generator features and their usage and purpose.

--- a/docs/docs/quickstart/index.md
+++ b/docs/docs/quickstart/index.md
@@ -1,0 +1,94 @@
+---
+sidebar_position: 2
+---
+import QuickStartCommon from "@site/docs/_quickstart_common.md"
+
+# Quick-Start
+
+The Quick-Start guide explains how in a few steps you get from an API definition to a functional _Rust_ example.
+
+Steps one and two are universal for other technologies. In step two you will choose a concrete _rust_ template.
+For more general information about first steps with ApiGear see [First Steps](/docs/guide/quick-start).
+
+The quick start enables only basic features: the [api](../features/api.md) generation and a ready-to-use [stub](../features/stubs.md) implementation.
+For all available features check the [overview](../features/features.md).
+
+<QuickStartCommon />
+
+## 5. Use the generated Cargo workspace
+
+The _rust_ template generates a [Cargo](https://doc.rust-lang.org/cargo/) workspace. Each API module becomes its own member crate, and a shared `examples` crate ties them together with runnable programs. To build and run the code you need a working [Rust toolchain](https://www.rust-lang.org/tools/install) (`rustc` and `cargo`, 1.80 or newer).
+
+:::note
+Basic Rust knowledge is necessary.
+:::
+
+### Project folder structure
+
+With the output directory set as in the example, both _ApiGear_ files reside in an `apigear` subfolder next to the generated _Rust_ workspace.
+In this case the folder structure should look similar to this:
+
+```bash
+📂hello-world
+ ┣ 📂apigear
+ ┃ ┣ 📜helloworld.solution.yaml
+ ┃ ┗ 📜helloworld.module.yaml
+ ┣ 📂rust_hello_world
+ ┃ ┣ 📜Cargo.toml          # workspace manifest (lists every module crate)
+ ┃ ┣ 📜rustfmt.toml
+ # highlight-next-line
+ ┃ ┣ 📂io_world            # one crate per module
+ ┃ ┃ ┣ 📜Cargo.toml
+ ┃ ┃ ┣ 📂src
+ ┃ ┃ ┃ ┣ 📜lib.rs
+ ┃ ┃ ┃ ┣ 📂api             # interface traits + Publisher + data structs/enums
+ ┃ ┃ ┃ ┣ 📂core_types      # property bundle + shared reference
+ ┃ ┃ ┃ ┗ 📂implementation  # ready-to-use default impl
+ ┃ ┃ ┗ 📂tests             # per-interface unit tests
+ ┃ ┗ 📂examples            # runnable example programs
+```
+
+Using the solution file from the previous paragraph the code is generated in the `rust_hello_world` folder, with a subfolder (member crate) for each module — here `io_world`, the name of the module defined in line 2 of `helloworld.module.yaml`. It contains both generated features: the basic [api](../features/api.md) and a [stub](../features/stubs.md) implementation.
+
+The `io_world/src/api/` folder contains the trait definitions for your interfaces along with the `serde`-enabled enums and structs for your module, while `io_world/src/core_types/` holds the per-interface support types (a property bundle for state sync and a shared-reference helper). The `io_world/src/implementation/` folder holds a default implementation you can use as-is or build on.
+
+:::tip
+Check our `examples` crate with all features enabled to get more working examples — including IPC clients and servers for [OLink](../features/olink.md), [MQTT](../features/mqtt.md) and [NATS](../features/nats.md).
+:::
+
+:::note
+For the simulation, check [the olink feature](../features/olink.md) which provides a middle layer on your code side, and the [simulation](/docs/scripting/backends/intro) explained.
+:::
+
+### Build the workspace
+
+Open a terminal, navigate to the generated `rust_hello_world` folder and build everything with Cargo:
+
+```bash
+cargo build
+```
+
+`cargo` resolves the workspace from the top-level `Cargo.toml`, downloads the dependencies, and compiles every module crate together with the `examples` crate.
+
+### Run an example
+
+The generated `examples` crate ships a runnable program that exercises every interface in-process — calling operations, setting properties and listing available signals. Run it with:
+
+```bash
+cargo run -p rust_hello_world_examples
+```
+
+:::note
+The example crate's package name is derived from your solution target, with an `_examples` suffix. If your target is named `rust_hello_world`, the package is `rust_hello_world_examples`. Check the `[package] name` in `examples/Cargo.toml` and run `cargo run -p <name>` accordingly.
+:::
+
+### Run the tests
+
+Each interface comes with a generated unit test that instantiates the default implementation and exercises its operations and properties. Run them with:
+
+```bash
+cargo test
+```
+
+From now on you can simply add your module crate to your own `Cargo.toml` as a dependency and use the generated traits, data types and default implementation.
+For more details on the generated features please check [api](../features/api.md) and [stubs](../features/stubs.md).


### PR DESCRIPTION
## Summary
Adds the Docusaurus documentation for the Rust SDK template, consumed by the
[apigear-docs](https://github.com/apigear-io/apigear-docs) site as a submodule
(`template-docs/template-rust`) — comparable to the other technology templates.

Authored with the technical-writer agent, grounded in the actual generated code
under `goldenmaster/tb_simple/` and modeled on the C++17 template docs.

### Pages (`docs/docs/`)
- `intro.md` — landing page
- `quickstart/index.md` — Cargo-based quick start (shared `_quickstart_common`)
- `features/features.md` — overview (core: api/core/stubs; extended: monitor/olink/mqtt/nats/examples)
- `features/api.md` — traits, `ApiFuture` + `_async` companion, the tokio-channel `Publisher`, `ApiError`, serde data types
- `features/stubs.md` — default implementations, workspace, examples, unit tests
- `features/monitor.md` — `tracing` decorator
- `features/olink.md` — ObjectLink adapters + simulation connectivity
- `features/mqtt.md` — MQTT adapters (`rumqttc`)
- `features/nats.md` — NATS adapters (`async-nats`)

Plus static assets (reused diagrams/logo) and the shared Hello World sample API.

Verified with `npm run build` in apigear-docs (no broken links, valid MDX).
